### PR TITLE
fix(cli): use $XDG_DATA_HOME instead of $HOME on Linux

### DIFF
--- a/src/cli/utils.cpp
+++ b/src/cli/utils.cpp
@@ -44,7 +44,17 @@ std::string createAndGetAppDir(std::string dir) {
         if (!std::getenv("HOME"))
             return "";
         home = std::getenv("HOME");
+#ifdef __linux__
+        if (!std::getenv("XDG_DATA_HOME")) {
+            dir = home + "/.local/share/bredbandskollen";
+        } else {
+            std::string xdg_data_home = std::getenv("XDG_DATA_HOME");
+            dir = xdg_data_home + "/bredbandskollen";
+        }
+#else
+        // Fall back to $HOME for other platforms
         dir = home + "/.bredbandskollen";
+#endif
     }
     int status = mkdir(dir.c_str(), 0755);
     if (status && errno != EEXIST) {


### PR DESCRIPTION
Follow Freedesktop.org's XDG Base Directory Specification by either using $XDG_DATA_HOME or falling
back to ~/.local/share. Ifdef'd to only apply to Linux builds, but could probably safely be enabled
on *BSDs by someone more familiar with the prevalence of XDG directories on those platforms.

BREAKING CHANGE: This changes the data directory and makes no attempt at falling back to the old
one. User data must be manually migrated to the new location if the user wishes to keep it.