### PR TITLE
Include cstdint where needed

### DIFF
--- a/src/http/httphost.h
+++ b/src/http/httphost.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <cstdint>
 

--- a/src/http/sha1.h
+++ b/src/http/sha1.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <cstdint>


### PR DESCRIPTION
Both g++ and clang++ seems to want this when i try to build the CLI.