### PR TITLE
Revert "Include cstdint where needed"

### DIFF
--- a/src/http/httphost.h
+++ b/src/http/httphost.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include <string>
 #include <cstdint>
 

--- a/src/http/sha1.h
+++ b/src/http/sha1.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include <iostream>
 #include <string>
 #include <cstdint>


### PR DESCRIPTION
Reverts dotse/bbk#18

Redundant with c61751c49ed40d4646b6cc9c9463e1bd4e2a3c77
Sorry!