### PR TITLE
Move sys/types.h include to header file

### DIFF
--- a/src/framework/engine.cpp
+++ b/src/framework/engine.cpp
@@ -2,7 +2,6 @@
 // Written by Göran Andersson <initgoran@gmail.com>
 
 #include <string.h>
-#include <sys/types.h>
 #ifdef _WIN32
 #include <winsock2.h>
 #else

--- a/src/framework/engine.h
+++ b/src/framework/engine.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <sys/types.h>
 
 #include "logger.h"
 


### PR DESCRIPTION
Required for use of fd_set.

--

I hope i didn't screw up and duplicate something this time...

When cross-compiling the cli for OpenWRT, i get (several of) the following error:

```
In file included from ../measurement/../http/../framework/eventloop.h:10,
                 from ../measurement/../http/../framework/task.h:10,
                 from ../measurement/../http/httptask.h:6,
                 from ../measurement/../http/httpclienttask.h:6,
                 from ../measurement/measurementtask.h:3,
                 from ../measurement/progresstask.h:3,
                 from ../measurement/wsdownloadtask.h:6,
                 from ../measurement/wsdownloadtask.cpp:4:
../measurement/../http/../framework/engine.h:127:16: error: 'fd_set' has not been declared
  127 |     int setFds(fd_set &r, fd_set &w, fd_set &e);
      |                ^~~~~~
../measurement/../http/../framework/engine.h:127:27: error: 'fd_set' has not been declared
  127 |     int setFds(fd_set &r, fd_set &w, fd_set &e);
      |                           ^~~~~~
../measurement/../http/../framework/engine.h:127:38: error: 'fd_set' has not been declared
  127 |     int setFds(fd_set &r, fd_set &w, fd_set &e);
      |                                      ^~~~~~
../measurement/../http/../framework/engine.h:131:22: error: 'fd_set' does not name a type
  131 |     void doFds(const fd_set &r, const fd_set &w, const fd_set &e, int max);
      |                      ^~~~~~
../measurement/../http/../framework/engine.h:131:39: error: 'fd_set' does not name a type
  131 |     void doFds(const fd_set &r, const fd_set &w, const fd_set &e, int max);
      |                                       ^~~~~~
../measurement/../http/../framework/engine.h:131:56: error: 'fd_set' does not name a type
  131 |     void doFds(const fd_set &r, const fd_set &w, const fd_set &e, int max);
      |                                                        ^~~~~~
In file included from ../framework/eventloop.h:10,
                 from ../framework/eventloop.cpp:8:
../framework/engine.h:127:16: error: 'fd_set' has not been declared
  127 |     int setFds(fd_set &r, fd_set &w, fd_set &e);
      | 
```

With moving the include of sys/types.h to the header, the compile succeeds (and the result works).