### PR TITLE
Add build/release workflow for Linux, Windows, MacOS, FreeBSD and OpenBSD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release binaries
+
+concurrency:
+  group: release
+  cancel-in-progress: true
+
+on:
+  push:
+    tags:
+      - "**"
+
+jobs:
+  build:
+    name: Build binaries
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: |
+          cd src/cli
+          make -j
+          mv cli bbk
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bbk
+          path: src/cli/bbk
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup | Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/.
+
+      - name: Setup | Generate release notes
+        run: git log -1 --pretty='%s' > RELEASE.md
+
+      - name: Build | Publish
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**
+          body_path: RELEASE.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,15 @@ on:
   push:
     tags:
       - "**"
+  workflow_dispatch:
 
 jobs:
-  build:
-    name: Build binaries
-    runs-on: ubuntu-22.04
+  build-linux:
+    name: Build Linux
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        arch: [amd64, arm64, armhf, i386, mips]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,34 +25,99 @@ jobs:
         run: |
           cd src/cli
           make -j
-          mv cli bbk
+          mv cli bbk-linux-${{ matrix.arch }}
 
-      - name: Upload artifacts
+      - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: bbk
-          path: src/cli/bbk
+          name: bbk-linux-${{ matrix.arch }}
+          path: src/cli/bbk-linux-${{ matrix.arch }}
+
+  build-macos:
+    name: Build macOS
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          cd src/cli
+          make -j
+          mv cli bbk-macos-amd64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bbk-macos-amd64
+          path: src/cli/bbk-macos-amd64
+
+  build-windows:
+    name: Build Windows
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add msbuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build
+        run: |
+          msbuild src/wincli/wincli.sln /p:Configuration=Release /m
+          mv src/wincli/x64/Release/wincli.exe bbk-windows-amd64.exe
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bbk-windows-amd64
+          path: bbk-windows-amd64.exe
+
+  build-freebsd:
+    name: Build FreeBSD
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: vmactions/freebsd-vm@v1
+        with:
+          run: |
+            pkg install -y gmake gcc
+            cd src/cli && gmake && mv cli bbk-freebsd-amd64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bbk-freebsd-amd64
+          path: src/cli/bbk-freebsd-amd64
+
+  build-openbsd:
+    name: Build OpenBSD
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: vmactions/openbsd-vm@v1
+        with:
+          run: |
+            pkg_add gmake gcc
+            cd src/cli && gmake && mv cli bbk-openbsd-amd64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bbk-openbsd-amd64
+          path: src/cli/bbk-openbsd-amd64
 
   release:
     name: Create GitHub Release
-    needs: build
-    permissions:
-      contents: write
-    runs-on: ubuntu-22.04
+    needs:
+      - build-linux
+      - build-macos
+      - build-windows
+      - build-freebsd
+      - build-openbsd
+    runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup | Download artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          path: artifacts/.
+          path: artifacts/
 
-      - name: Setup | Generate release notes
+      - name: Generate release notes
         run: git log -1 --pretty='%s' > RELEASE.md
 
-      - name: Build | Publish
+      - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/**
+          files: artifacts/**/*
           body_path: RELEASE.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
   push:
     tags:
       - "**"
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -98,6 +99,7 @@ jobs:
 
   release:
     name: Create GitHub Release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs:
       - build-linux
       - build-macos


### PR DESCRIPTION
Add github action release workflow that automatically publishes release with built binary on tags.