### PR TITLE
json11: include <cstdint> for uint8_t

### DIFF
--- a/src/json11/json11.cpp
+++ b/src/json11/json11.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <clocale>
 #include <limits>
+#include <cstdint>
 
 namespace json11 {
 


### PR DESCRIPTION
`json11.cpp` uses `uint8_t` but does not `include <cstdint>`. This adds the missing header to avoid relying on transitive includes and to restore portability on stricter toolchains.